### PR TITLE
Updating object schemas

### DIFF
--- a/lib/recurly/account.ex
+++ b/lib/recurly/account.ex
@@ -10,24 +10,24 @@ defmodule Recurly.Account do
   @endpoint "/accounts"
 
   schema :account do
-    field :accept_language
-    field :account_code
-    field :address, Recurly.Address
-    field :billing_info, Recurly.BillingInfo
-    field :cc_emails
-    field :closed_at, :date_time
-    field :company_name, :string
-    field :created_at, :date_time
-    field :email
-    field :entity_use_code
-    field :first_name
-    field :last_name
-    field :state, :string, read_only: true
-    field :tax_exempt, :boolean
-    field :transactions, Recurly.Transaction, list: true
-    field :updated_at, :date_time
-    field :username
-    field :vat_number
+    field :accept_language, :string
+    field :account_code,    :string
+    field :address,         Recurly.Address
+    field :billing_info,    Recurly.BillingInfo
+    field :cc_emails,       :string
+    field :closed_at,       :date_time, read_only: true
+    field :company_name,    :string
+    field :created_at,      :date_time, read_only: true
+    field :email,           :string
+    field :entity_use_code, :string
+    field :first_name,      :string
+    field :last_name,       :string
+    field :state,           :string, read_only: true
+    field :tax_exempt,      :boolean
+    field :transactions,    Recurly.Transaction, list: true
+    field :updated_at,      :date_time, read_only: true
+    field :username,        :string
+    field :vat_number,      :string
   end
 
   @doc """

--- a/lib/recurly/add_on.ex
+++ b/lib/recurly/add_on.ex
@@ -10,9 +10,19 @@ defmodule Recurly.AddOn do
   @endpoint "plans/<%= plan_code %>/add_ons"
 
   schema :add_on do
-    field :add_on_code
-    field :name
-    field :unit_amount_in_cents, Recurly.Money
+    field :accounting_code,                 :string
+    field :add_on_code,                     :string
+    field :add_on_type,                     :string
+    field :default_quantity,                :integer
+    field :display_quantity_on_hosted_page, :boolean
+    field :measured_unit_id,                :string
+    field :name,                            :string
+    field :optional,                        :boolean
+    field :revenue_schedule_type,           :string
+    field :tax_code,                        :string
+    field :unit_amount_in_cents,            Recurly.Money
+    field :usage_percentage,                :string
+    field :usage_type,                      :string
   end
 
   @doc """

--- a/lib/recurly/address.ex
+++ b/lib/recurly/address.ex
@@ -5,12 +5,12 @@ defmodule Recurly.Address do
   use Recurly.Resource
 
   schema :address do
-    field :address1
-    field :address2
-    field :city
-    field :country
-    field :phone
-    field :state
-    field :zip
+    field :address1, :string
+    field :address2, :string
+    field :city,     :string
+    field :country,  :string
+    field :phone,    :string
+    field :state,    :string
+    field :zip,      :string
   end
 end

--- a/lib/recurly/billing_info.ex
+++ b/lib/recurly/billing_info.ex
@@ -7,26 +7,26 @@ defmodule Recurly.BillingInfo do
   use Recurly.Resource
 
   schema :billing_info do
-    field :address1
-    field :address2
-    field :card_type
-    field :city
-    field :company
-    field :country
-    field :currency
-    field :first_name
-    field :first_six
-    field :ip_address
-    field :last_four
-    field :last_name
-    field :month, :integer
-    field :number
-    field :phone
-    field :state
-    field :token_id
-    field :vat_number
-    field :verification_value
-    field :year, :integer
-    field :zip
+    field :address1,           :string
+    field :address2,           :string
+    field :card_type,          :string
+    field :city,               :string
+    field :company,            :string
+    field :country,            :string
+    field :currency,           :string
+    field :first_name,         :string
+    field :first_six,          :string
+    field :ip_address,         :string
+    field :last_four,          :string
+    field :last_name,          :string
+    field :month,              :integer
+    field :number,             :string
+    field :phone,              :string
+    field :state,              :string
+    field :token_id,           :string
+    field :vat_number,         :string
+    field :verification_value, :string
+    field :year,               :integer
+    field :zip,                :string
   end
 end

--- a/lib/recurly/coupon.ex
+++ b/lib/recurly/coupon.ex
@@ -10,25 +10,25 @@ defmodule Recurly.Coupon do
   @endpoint "/coupons"
 
   schema :coupon do
-    field :coupon_code
-    field :name
-    field :discount_type
-    field :discount_in_cents, Recurly.Money
-    field :discount_percent, :integer
-    field :invoice_description
-    field :single_use, :boolean
-    field :applies_for_months, :integer
-    field :applies_to_all_plans, :boolean
-    field :max_redemptions, :integer
-    field :duration
-    field :temporal_unit
-    field :temporal_amount, :integer
+    field :applies_to_all_plans,        :boolean
     field :applies_to_non_plan_charges, :boolean
-    field :redemption_resource
+    field :coupon_code,                 :string
+    field :coupon_type,                 :string
+    field :description,                 :string
+    field :discount_type,               :string
+    field :discount_in_cents,           Recurly.Money
+    field :discount_percent,            :integer
+    field :duration,                    :string
+    field :invoice_description,         :string
+    field :max_redemptions,             :integer
     field :max_redemptions_per_account, :integer
-    field :coupon_type
-    field :unique_code_template
-    #field :plan_codes
+    field :name,                        :string
+    field :plan_codes,                  list: true
+    field :redeem_by_date,              :string
+    field :temporal_unit,               :string
+    field :temporal_amount,             :integer
+    field :redemption_resource,         :string
+    field :unique_code_template,        :string
   end
 
   @doc """

--- a/lib/recurly/plan.ex
+++ b/lib/recurly/plan.ex
@@ -10,25 +10,24 @@ defmodule Recurly.Plan do
   @endpoint "/plans"
 
   schema :plan do
-    field :accounting_code
-    field :cancel_url
-    field :display_quantity, :boolean
-    field :name
-    field :plan_code
-    field :plan_interval_unit
-    field :plan_interval_length, :integer
-    field :revenue_schedule_type
-    field :setup_fee_accounting_code
-    field :setup_fee_in_cents, Recurly.Money
-    field :setup_fee_revenue_schedule_type
-    field :success_url
-    field :total_billing_cycles
-    field :trial_interval_unit
-    field :trial_interval_length, :integer
-    field :unit_amount_in_cents, Recurly.Money
-    field :unit_name
-    field :tax_code
-    field :tax_exempt, :boolean
+    field :accounting_code,                 :string
+    field :display_quantity,                :boolean
+    field :description,                     :string
+    field :name,                            :string
+    field :plan_code,                       :string
+    field :plan_interval_unit,              :string
+    field :plan_interval_length,            :integer
+    field :revenue_schedule_type,           :string
+    field :setup_fee_accounting_code,       :string
+    field :setup_fee_in_cents,              Recurly.Money
+    field :setup_fee_revenue_schedule_type, :string
+    field :success_url,                     :string
+    field :total_billing_cycles,            :string
+    field :trial_interval_unit,             :string
+    field :trial_interval_length,           :integer
+    field :unit_amount_in_cents,            Recurly.Money
+    field :tax_code,                        :string
+    field :tax_exempt,                      :boolean
   end
 
   @doc """

--- a/lib/recurly/subscription.ex
+++ b/lib/recurly/subscription.ex
@@ -12,24 +12,38 @@ defmodule Recurly.Subscription do
   @endpoint "/subscriptions"
 
   schema :subscription do
-    field :account, Recurly.Account
-    field :activated_at, :date_time
-    field :canceled_at, :date_time
-    field :currency
-    field :current_period_started_at, :date_time
-    field :expires_at, :date_time
-    field :plan, Recurly.Plan
-    field :plan_code
-    field :quantity, :integer
-    field :state, :string, read_only: true
-    field :subscription_add_ons, Recurly.SubscriptionAddOn, list: true
-    field :tax_in_cents, :integer
-    field :tax_rate, :float
-    field :tax_region
-    field :tax_type
-    field :unit_amount_in_cents, :integer
-    field :updated_at, :date_time
-    field :uuid
+    field :account,                    Recurly.Account
+    field :activated_at,               :date_time, read_only: true
+    field :canceled_at,                :date_time, read_only: true
+    field :currency,                   :string
+    field :current_period_started_at,  :date_time
+    field :expires_at,                 :date_time, read_only: true
+    field :bank_account_authorized_at, :string
+    field :bulk,                       :boolean
+    field :coupon_code,                :string
+    field :collection_method,          :string
+    field :customer_notes,             :string
+    field :first_renewal_date,         :date_time
+    field :net_terms,                  :string
+    field :plan,                       Recurly.Plan
+    field :plan_code,                  :string
+    field :po_number,                  :string
+    field :quantity,                   :integer
+    field :state,                      :string, read_only: true
+    field :subscription_add_ons,       Recurly.SubscriptionAddOn, list: true
+    field :starts_at,                  :date_time
+    field :tax_in_cents,               :integer
+    field :tax_rate,                   :float
+    field :tax_region,                 :string
+    field :tax_type,                   :string
+    field :terms_and_conditions,       :string
+    field :total_billing_cycles,       :string
+    field :trial_ends_at,              :date_time
+    field :unit_amount_in_cents,       :integer
+    field :updated_at,                 :date_time, read_only: true
+    field :uuid,                       :string
+    field :vat_reverse_charge_notes,   :string
+    field :revenue_schedule_type,      :string
   end
 
   @doc """

--- a/lib/recurly/subscription_add_on.ex
+++ b/lib/recurly/subscription_add_on.ex
@@ -7,8 +7,10 @@ defmodule Recurly.SubscriptionAddOn do
   use Recurly.Resource
 
   schema :subscription_add_on do
-    field :add_on_code
-    field :quantity, :integer
-    field :unit_amount_in_cents, Recurly.Money
+    field :add_on_code,           :string
+    field :quantity,              :integer
+    field :revenue_schedule_type, :string
+    field :unit_amount_in_cents,  Recurly.Money
+    field :usage_percentage,      :string
   end
 end

--- a/lib/recurly/transaction.ex
+++ b/lib/recurly/transaction.ex
@@ -10,21 +10,20 @@ defmodule Recurly.Transaction do
   @endpoint "/transactions"
 
   schema :transaction do
-    field :action
-    field :amount_in_cents, :integer
-    field :currency
-    field :details, Recurly.TransactionDetails, read_only: true
-    field :ip_address
-    field :payment_method
-    field :recurring_type, :boolean
-    field :reference
-    field :refundable_type, :boolean
-    field :source
-    field :tax_in_cents, :integer
-    field :test_type, :boolean
-    field :transaction_code
-    field :uuid
-    field :voidable_type, :boolean
+    field :amount_in_cents,  :integer
+    field :currency,         :string
+    field :details,          Recurly.TransactionDetails, read_only: true
+    field :ip_address,       :string
+    field :payment_method,   :string
+    field :recurring_type,   :boolean
+    field :reference,        :string
+    field :refundable_type,  :boolean
+    field :source,           :string
+    field :tax_in_cents,     :integer
+    field :test_type,        :boolean
+    field :transaction_code, :string
+    field :uuid,             :string
+    field :voidable_type,    :boolean
   end
 
   @doc """

--- a/lib/recurly/xml/schema.ex
+++ b/lib/recurly/xml/schema.ex
@@ -63,7 +63,7 @@ defmodule Recurly.XML.Schema do
   @doc """
   Defines a field in the schema
   """
-  defmacro field(name, type \\ :string, opts \\ []) do
+  defmacro field(name, type, opts \\ []) do
     quote do
       Recurly.XML.Schema.__field__(__MODULE__, unquote(name), unquote(type), unquote(opts))
     end


### PR DESCRIPTION
This PR makes the schema on each object a bit more cleaner by removing the default field type of `string` and setting the type on each object. 

I've got to add some good test cases here to ensure each object can be created successfully. 
