### PR TITLE
Adding parens to 0-arity function calls

### DIFF
--- a/lib/recurly.ex
+++ b/lib/recurly.ex
@@ -320,5 +320,5 @@ defmodule Recurly do
   end
 
   @doc false
-  def user_agent, do: "Recurly/Elixir/#{client_version}"
+  def user_agent, do: "Recurly/Elixir/#{client_version()}"
 end

--- a/lib/recurly/api.ex
+++ b/lib/recurly/api.ex
@@ -83,7 +83,7 @@ defmodule Recurly.API do
     defaults = [
       recv_timeout: 15_000,
       timeout: 15_000,
-      hackney: [basic_auth: {api_key, ""}]
+      hackney: [basic_auth: {api_key(), ""}]
     ]
 
     Keyword.merge(defaults, extras)
@@ -100,7 +100,7 @@ defmodule Recurly.API do
     case URI.parse(path) do
       %{scheme: "https"} -> path
       %{scheme: "http"} -> path
-       _ -> Path.join("https://#{api_subdomain}.recurly.com/v2", path)
+       _ -> Path.join("https://#{api_subdomain()}.recurly.com/v2", path)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -9,9 +9,9 @@ defmodule Recurly.Mixfile do
      start_permanent: Mix.env == :prod,
      consolidate_protocols: Mix.env == :prod,
      docs: [main: "Recurly"],
-     description: description,
-     package: package,
-     deps: deps,
+     description: description(),
+     package: package(),
+     deps: deps(),
      test_coverage: [tool: ExCoveralls],
      preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test]
    ]


### PR DESCRIPTION
This PR adds parens to function calls with 0-arity, which will suppress warnings, which were introduced in [v1.4](https://github.com/elixir-lang/elixir/blob/v1.4/CHANGELOG.md#2-bug-fixes).