### PR TITLE
Upgrade 2.5 api

### DIFF
--- a/lib/recurly.ex
+++ b/lib/recurly.ex
@@ -311,7 +311,7 @@ defmodule Recurly do
   """
 
   @doc false
-  def api_version, do: "2.4"
+  def api_version, do: "2.5"
 
   @doc false
   def client_version do

--- a/lib/recurly/account.ex
+++ b/lib/recurly/account.ex
@@ -5,7 +5,7 @@ defmodule Recurly.Account do
   for more details
   """
   use Recurly.Resource
-  alias Recurly.{Resource,Account,BillingInfo,Address,Transaction,Adjustment,Invoice,Subscription}
+  alias Recurly.{Resource, Account, BillingInfo, Address, Transaction, Adjustment, Invoice, Subscription}
 
   @endpoint "/accounts"
 
@@ -22,6 +22,11 @@ defmodule Recurly.Account do
     field :email,               :string
     field :entity_use_code,     :string
     field :first_name,          :string
+    field :has_active_subscription, :boolean
+    field :has_canceled_subscription, :boolean
+    field :has_future_subscription, :boolean
+    field :has_live_subscription, :boolean
+    field :has_past_due_invoice, :boolean
     field :hosted_login_token,  :string, read_only: true
     field :invoices,            Invoice, list: true, read_only: true
     field :last_name,           :string

--- a/lib/recurly/adjustment.ex
+++ b/lib/recurly/adjustment.ex
@@ -5,9 +5,10 @@ defmodule Recurly.Adjustment do
   for more details
   """
   use Recurly.Resource
-  alias Recurly.{Resource,Adjustment,Account,Invoice,Subscription}
+  alias Recurly.{Resource, Adjustment, Account, Invoice, Subscription}
 
   @account_endpoint "/accounts/<%= account_code %>/adjustments"
+  @invoice_endpoint "/invoices/<%= invoice_number %>/adjustments"
   @find_endpoint "/adjustments/<%= uuid %>"
 
   schema :adjustment do
@@ -86,6 +87,10 @@ defmodule Recurly.Adjustment do
   def stream(account_code, options \\ []) do
     Resource.stream(Adjustment, account_path(account_code), options)
   end
+  # FIXME: How should this be handled?
+  # def stream(invoice_number, options \\ []) do
+  #   Resource.stream(Adjustment, invoice_path(invoice_number), options)
+  # end
 
   @doc """
   Creates an adjustment from a changeset.
@@ -122,6 +127,10 @@ defmodule Recurly.Adjustment do
   """
   def account_path(account_code) do
     EEx.eval_string(@account_endpoint, account_code: account_code)
+  end
+
+  def invoice_path(invoice_number) do
+    EEx.eval_string(@account_endpoint, invoice_number: invoice_number)
   end
 
   @doc """

--- a/lib/recurly/billing_info.ex
+++ b/lib/recurly/billing_info.ex
@@ -32,6 +32,7 @@ defmodule Recurly.BillingInfo do
     field :routing_number,              :string
     field :state,                       :string
     field :token_id,                    :string
+    field :updated_at,                  :date_time, read_only: true
     field :vat_number,                  :string
     field :verification_value,          :string
     field :year,                        :integer

--- a/lib/recurly/coupon.ex
+++ b/lib/recurly/coupon.ex
@@ -5,7 +5,7 @@ defmodule Recurly.Coupon do
   for more details
   """
   use Recurly.Resource
-  alias Recurly.{Resource,Coupon,Money}
+  alias Recurly.{Resource, Coupon, Money}
 
   @endpoint "/coupons"
 
@@ -21,6 +21,7 @@ defmodule Recurly.Coupon do
     field :discount_in_cents,           Money
     field :discount_percent,            :integer
     field :duration,                    :string
+    field :id,                          :integer
     field :invoice_description,         :string
     field :max_redemptions,             :integer
     field :max_redemptions_per_account, :integer

--- a/lib/recurly/invoice.ex
+++ b/lib/recurly/invoice.ex
@@ -5,13 +5,14 @@ defmodule Recurly.Invoice do
   for more details
   """
   use Recurly.Resource
-  alias Recurly.{Resource,Invoice,Account,Address,Adjustment,Transaction}
+  alias Recurly.{Resource, Invoice, Account, Address, Adjustment, Transaction}
 
   @endpoint "/invoices"
 
   schema :invoice do
     field :account,               Account
     field :address,               Address
+    field :attempt_next_collection_at, :date_time, read_only: true
     field :closed_at,             :date_time, read_only: true
     field :collection_method,     :string
     field :created_at,            :date_time, read_only: true
@@ -22,7 +23,9 @@ defmodule Recurly.Invoice do
     field :line_items,            Adjustment, list: true
     field :net_terms,             :integer
     field :po_number,             :string
+    field :recovery_reason,       :string
     field :state,                 :string
+    field :subtotal_after_discount_in_cents, :integer
     field :subtotal_in_cents,     :integer
     field :tax_in_cents,          :integer
     field :tax_rate,              :float

--- a/lib/recurly/subscription.ex
+++ b/lib/recurly/subscription.ex
@@ -7,7 +7,7 @@ defmodule Recurly.Subscription do
   TODO implement postpone and reactivate
   """
   use Recurly.Resource
-  alias Recurly.{Resource,Subscription,Account,SubscriptionAddOn,Plan,Invoice}
+  alias Recurly.{Resource, Subscription, Account, SubscriptionAddOn, Plan, Invoice}
 
   @endpoint "/subscriptions"
 
@@ -18,6 +18,7 @@ defmodule Recurly.Subscription do
     field :bulk,                       :boolean
     field :canceled_at,                :date_time, read_only: true
     field :collection_method,          :string
+    field :converted_at,               :date_time, read_only: true
     field :coupon_code,                :string
     field :customer_notes,             :string
     field :currency,                   :string
@@ -30,6 +31,7 @@ defmodule Recurly.Subscription do
     field :plan_code,                  :string
     field :po_number,                  :string
     field :quantity,                   :integer
+    field :started_with_gift,          :boolean
     field :state,                      :string, read_only: true
     field :subscription_add_ons,       SubscriptionAddOn, list: true
     field :starts_at,                  :date_time

--- a/lib/recurly/transaction.ex
+++ b/lib/recurly/transaction.ex
@@ -5,7 +5,7 @@ defmodule Recurly.Transaction do
   for more details
   """
   use Recurly.Resource
-  alias Recurly.{Resource,Transaction,TransactionDetails,Account,Invoice,Subscription}
+  alias Recurly.{Resource, Transaction, TransactionDetails, Account, Invoice, Subscription}
 
   @endpoint "/transactions"
 
@@ -13,10 +13,16 @@ defmodule Recurly.Transaction do
     field :account,               Account, read_only: true
     field :action,                :string
     field :amount_in_cents,       :integer
+    field :approval_code,         :string
     field :currency,              :string
+    field :collected_at,          :date_time, read_only: true
+    field :description,           :string
     field :details,               TransactionDetails, read_only: true
+    field :gateway_type,          :string
     field :invoice,               Invoice, read_only: true
     field :ip_address,            :string
+    field :message,               :string
+    field :origin,                :string
     field :original_transaction,  Transaction, read_only: true
     field :payment_method,        :string
     field :recurring_type,        :boolean

--- a/test/recurly/account_test.exs
+++ b/test/recurly/account_test.exs
@@ -16,6 +16,11 @@ defmodule Recurly.AccountTest do
     email
     entity_use_code
     first_name
+    has_active_subscription
+    has_canceled_subscription
+    has_future_subscription
+    has_live_subscription
+    has_past_due_invoice
     hosted_login_token
     invoices
     last_name
@@ -38,6 +43,11 @@ defmodule Recurly.AccountTest do
     email
     entity_use_code
     first_name
+    has_active_subscription
+    has_canceled_subscription
+    has_future_subscription
+    has_live_subscription
+    has_past_due_invoice
     last_name
     tax_exempt
     username

--- a/test/recurly/billing_info_test.exs
+++ b/test/recurly/billing_info_test.exs
@@ -28,6 +28,7 @@ defmodule Recurly.BillingInfoTest do
     routing_number
     state
     token_id
+    updated_at
     vat_number
     verification_value
     year

--- a/test/recurly/coupon_test.exs
+++ b/test/recurly/coupon_test.exs
@@ -15,6 +15,7 @@ defmodule Recurly.CouponTest do
     discount_in_cents
     discount_percent
     duration
+    id
     invoice_description
     max_redemptions
     max_redemptions_per_account
@@ -35,10 +36,11 @@ defmodule Recurly.CouponTest do
     coupon_code
     coupon_type
     description
-    discount_type
     discount_in_cents
     discount_percent
+    discount_type
     duration
+    id
     invoice_description
     max_redemptions
     max_redemptions_per_account

--- a/test/recurly/invoice_test.exs
+++ b/test/recurly/invoice_test.exs
@@ -6,6 +6,7 @@ defmodule Recurly.InvoiceTest do
   @readable_fields ~w(
     account
     address
+    attempt_next_collection_at
     closed_at
     collection_method
     created_at
@@ -16,7 +17,9 @@ defmodule Recurly.InvoiceTest do
     line_items
     net_terms
     po_number
+    recovery_reason
     state
+    subtotal_after_discount_in_cents
     subtotal_in_cents
     tax_in_cents
     tax_rate
@@ -41,7 +44,9 @@ defmodule Recurly.InvoiceTest do
     line_items
     net_terms
     po_number
+    recovery_reason
     state
+    subtotal_after_discount_in_cents
     subtotal_in_cents
     tax_in_cents
     tax_rate

--- a/test/recurly/subscription_test.exs
+++ b/test/recurly/subscription_test.exs
@@ -6,15 +6,16 @@ defmodule Recurly.SubscriptionTest do
   @readable_fields ~w(
     account
     activated_at
-    canceled_at
-    currency
-    current_period_started_at
-    expires_at
     bank_account_authorized_at
     bulk
-    coupon_code
+    canceled_at
     collection_method
+    converted_at
+    coupon_code
+    currency
+    current_period_started_at
     customer_notes
+    expires_at
     first_renewal_date
     invoice
     net_terms
@@ -22,9 +23,11 @@ defmodule Recurly.SubscriptionTest do
     plan_code
     po_number
     quantity
+    revenue_schedule_type
+    started_with_gift
+    starts_at
     state
     subscription_add_ons
-    starts_at
     tax_in_cents
     tax_rate
     tax_region
@@ -36,17 +39,16 @@ defmodule Recurly.SubscriptionTest do
     updated_at
     uuid
     vat_reverse_charge_notes
-    revenue_schedule_type
   )a
 
   @writeable_fields ~w(
     account
-    currency
-    current_period_started_at
     bank_account_authorized_at
     bulk
-    coupon_code
     collection_method
+    coupon_code
+    currency
+    current_period_started_at
     customer_notes
     first_renewal_date
     net_terms
@@ -54,8 +56,10 @@ defmodule Recurly.SubscriptionTest do
     plan_code
     po_number
     quantity
-    subscription_add_ons
+    revenue_schedule_type
+    started_with_gift
     starts_at
+    subscription_add_ons
     tax_in_cents
     tax_rate
     tax_region
@@ -66,7 +70,6 @@ defmodule Recurly.SubscriptionTest do
     unit_amount_in_cents
     uuid
     vat_reverse_charge_notes
-    revenue_schedule_type
   )a
 
   test "should maintain the list of writeable fields" do

--- a/test/recurly/transaction_test.exs
+++ b/test/recurly/transaction_test.exs
@@ -7,10 +7,16 @@ defmodule Recurly.TransactionTest do
     account
     action
     amount_in_cents
+    approval_code
+    collected_at
     currency
+    description
     details
+    gateway_type
     invoice
     ip_address
+    message
+    origin
     original_transaction
     payment_method
     recurring_type
@@ -28,8 +34,13 @@ defmodule Recurly.TransactionTest do
   @writeable_fields ~w(
     action
     amount_in_cents
+    approval_code
     currency
+    description
+    gateway_type
     ip_address
+    message
+    origin
     payment_method
     recurring_type
     reference


### PR DESCRIPTION
Figured I'd do the update incrementally. These are all the API changes listed for 2.5. The ones not checked off, I wasn't sure what to do with. I'm also not sure I'm correctly applying `read_only`. How can I tell if a field is read only? 

* Route changes:
  * [ ] Added PUT /v2/invoices/:invoice_number/collect

* Request and Response Changes:
  * Changed Subscription response:
    * [x] Added ``<started_with_gift>`` element.
    * [x] Added ``<converted_at>`` element.
  * Changed Billing Info response:
    * [x] Added ``<updated_at>`` element.
  * Changed Coupon response:
    * [x] Added ``<id>`` element.
  * Changed Invoice response:
    * [x] Added ``<subtotal_after_discount_in_cents>`` element.
    * [x] Added ``<attempt_next_collection_at>`` element.
    * [x] Added ``<recovery_reason>`` element.
    * [ ] Added ``<all_line_items>`` link when invoice response only shows first 500 line items.
  * Changed Transaction response:
    * [x] Added ``<gateway_type>`` element.
    * [x] Added ``<origin>`` element.
    * [x] Added ``<description>`` element.
    * [x] Added ``<message>`` element.
    * [x] Added `<approval_code>` element.
    * [x] Added `<collected_at>` element.
  * Changed Account response:
    * [x] Added `<has_live_subscription>` element.
    * [x] Added `<has_active_subscription>` element.
    * [x] Added `<has_future_subscription>` element.
    * [x] Added `<has_canceled_subscription>` element.
    * [x] Added `<has_past_due_invoice>` element.
    * [ ] Added GET /v2/invoices/:invoice_number/adjustments
  * Changed Adjustment POST request:
    * [ ] Added `<product_code>` element.
  * Changed Transactions POST request:
    * [ ] Added `<product_code>` element.
  * Changed Invoice Preview POST request:
    * [ ] Added optional `<currency>` element. This change affects all versions of the API.
  * Changed Invoice POST request:
    * [ ] Added optional `<currency>` element. This change affects all versions of the API.